### PR TITLE
Also publish the rtl433 attrs to each device node

### DIFF
--- a/rtl2mqtt.py
+++ b/rtl2mqtt.py
@@ -96,6 +96,7 @@ while True:
                 if item == "id":
                     subtopic += "/" + str(value)
 
+            mqttc.publish(MQTT_TOPIC+"/"+subtopic, payload=line, qos=MQTT_QOS, retain=True)
             for item in json_dict:
                 value = json_dict[item]
                 if not "model" in item:


### PR DESCRIPTION
This makes it easier for HomeAssistant to bring the whole set of attributes in for the entity.